### PR TITLE
Update environment configuration and enhance image upload path

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,2 +1,4 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vest-ic-local?sslmode=disable
 PAYLOAD_SECRET=test
+BLOB_READ_WRITE_TOKEN="get from vercel console"
+ENVIRONMENT="dev"

--- a/src/app/api/admin/posts/route.ts
+++ b/src/app/api/admin/posts/route.ts
@@ -27,9 +27,11 @@ export async function POST(request: Request) {
     let displayImageUrl: string | undefined;
 
     if (displayImage) {
+      const environment = process.env.ENVIRONMENT;
+      const environmentString = environment ? environment + "/" : "";
       displayImageUrl = await uploadToBlob(
         displayImage,
-        `posts/${slug}/display-image-${Date.now()}.jpg`
+        `posts/${slug}/${environmentString}display-image-${Date.now()}.jpg`
       );
     }
 


### PR DESCRIPTION
Until we upgrade to vercel pro we can only have one blob storage instance so I've set that to be used across all environments. I've added an environment string to the upload path to ensure uploads from different environments are separated. We'll be upgrading to pro soon so this should be temporary at least.

- Added new environment variables: BLOB_READ_WRITE_TOKEN and ENVIRONMENT to env.example.
- Modified the image upload path in the POST request handler to include the environment in the URL structure.