### PR TITLE
feat: add middleware for admin IP validation

### DIFF
--- a/env.example
+++ b/env.example
@@ -3,3 +3,4 @@ PAYLOAD_SECRET=test
 BLOB_READ_WRITE_TOKEN="get from vercel console"
 ENVIRONMENT="dev"
 BLOB_HOST="host@host.com"
+ADMIN_IPS="IP_1,IP_2"

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -76,7 +76,7 @@ export interface Config {
   };
   collectionsJoins: {
     posts: {
-      tags: "postTags";
+      tags: 'postTags';
     };
   };
   collectionsSelect: {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { headers } from "next/headers";
+
+const admin_ips: string[] =
+  process.env.ADMIN_IPS?.split(",").map((id) => id.trim()) || [];
+
+export async function middleware(request: NextRequest) {
+  if (process.env.ENVIRONMENT === "dev") {
+    return;
+  }
+
+  const headersList = headers();
+  const forwardedFor = (await headersList).get("x-forwarded-for");
+
+  const ipAddress = forwardedFor?.split(",").at(0) ?? undefined;
+  console.log(ipAddress);
+
+  if (ipAddress && admin_ips.includes(ipAddress)) {
+    return;
+  }
+  return NextResponse.redirect(new URL("/", request.url));
+}
+
+export const config = {
+  matcher: ["/admin/:path*", "/admin/(.*)"],
+};


### PR DESCRIPTION
This pull request introduces middleware to restrict access to admin routes based on IP addresses, adds a new environment variable to support this functionality

### Middleware for Admin Route Access Control:
* Added a new middleware in `src/middleware.ts` to restrict access to `/admin` routes based on IP addresses. The middleware checks the `x-forwarded-for` header against a list of allowed IPs defined in the `ADMIN_IPS` environment variable. If the IP is not allowed, the request is redirected to the homepage.

### Environment Variable Updates:
* Updated `env.example` to include a new `ADMIN_IPS` variable, which stores a comma-separated list of allowed admin IP addresses.
