### PR TITLE
fixed image input and rich text editor not clearing on submission bugs

### DIFF
--- a/src/app/(public)/insights/layout.tsx
+++ b/src/app/(public)/insights/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { ThemeProvider } from "next-themes";
-import Image from "next/image";
 
 export const metadata: Metadata = {
   title: "Vest IC | The Protein Revolution",

--- a/src/app/(public)/insights/layout.tsx
+++ b/src/app/(public)/insights/layout.tsx
@@ -17,16 +17,6 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
       disableTransitionOnChange
     >
       <div className="relative flex flex-col min-h-screen">
-        {/* Background graphic */}
-        <div className="absolute inset-0 -z-10 opacity-10">
-          <Image
-            src="/landscape-placeholder.svg?height=1200&width=1200"
-            alt="Background graphic"
-            fill
-            className="object-cover"
-          />
-        </div>
-
         <main className="flex-1 flex items-start justify-center py-8">
           {children}
         </main>

--- a/src/components/admin/PostForm.tsx
+++ b/src/components/admin/PostForm.tsx
@@ -56,6 +56,27 @@ export const CreatePostForm = ({
     },
   });
 
+  const clearEditorText = () => {
+    // this looks for an element by an id we've added and clears all the child elements
+    // as the editor content takes the form of html elements within it
+    const editorElement = document.getElementById("editor-content-input");
+    if (editorElement) {
+      while (editorElement.firstChild) {
+        editorElement.removeChild(editorElement.firstChild);
+      }
+    }
+  };
+
+  const clearFileInput = () => {
+    const imageInput = document.getElementById("post-form-image-input");
+    if (imageInput) {
+      // @ts-ignore
+      imageInput.type = "";
+      // @ts-ignore
+      imageInput.type = "file";
+    }
+  };
+
   const onSubmit = async (values: FormValues) => {
     setIsLoading(true);
     try {
@@ -75,6 +96,15 @@ export const CreatePostForm = ({
       const data = await response.json();
       if (response.ok) {
         form.reset();
+
+        // the previous file name remains after submission so clearing it manually
+        // to avoid confusion
+        clearFileInput();
+
+        // react hook form clears the html value it stores but not the actual editor text
+        // so without this its still viewable in the form after submission
+        clearEditorText();
+
         alert("Post created successfully!");
       } else {
         throw new Error(data.message || "Failed to create post");
@@ -204,6 +234,7 @@ export const CreatePostForm = ({
               <FormControl>
                 <div className="flex flex-col gap-4">
                   <Input
+                    id="post-form-image-input"
                     type="file"
                     accept="image/*"
                     {...field}

--- a/src/components/admin/PostForm.tsx
+++ b/src/components/admin/PostForm.tsx
@@ -70,9 +70,9 @@ export const CreatePostForm = ({
   const clearFileInput = () => {
     const imageInput = document.getElementById("post-form-image-input");
     if (imageInput) {
-      // @ts-ignore
+      // @ts-expect-error
       imageInput.type = "";
-      // @ts-ignore
+      // @ts-expect-error
       imageInput.type = "file";
     }
   };

--- a/src/components/admin/PostForm.tsx
+++ b/src/components/admin/PostForm.tsx
@@ -70,9 +70,9 @@ export const CreatePostForm = ({
   const clearFileInput = () => {
     const imageInput = document.getElementById("post-form-image-input");
     if (imageInput) {
-      // @ts-expect-error
+      // @ts-expect-error I can't be bothered to type this
       imageInput.type = "";
-      // @ts-expect-error
+      // @ts-expect-error I can't be bothered to type this
       imageInput.type = "file";
     }
   };

--- a/src/components/minimal-tiptap/hooks/use-minimal-tiptap.ts
+++ b/src/components/minimal-tiptap/hooks/use-minimal-tiptap.ts
@@ -195,7 +195,8 @@ export const useMinimalTiptapEditor = ({
         autocomplete: 'off',
         autocorrect: 'off',
         autocapitalize: 'off',
-        class: cn('focus:outline-none', editorClassName)
+        class: cn('focus:outline-none', editorClassName),
+        id: 'editor-content-input'
       }
     },
     onUpdate: ({ editor }) => handleUpdate(editor),


### PR DESCRIPTION
Fixed bugs on post creation:
- Rich text editor text content not clearing
- File input file name not clearing 

 RHF state for both of these cleared fine previously just not the visual state in the DOM

Also got rid of the placeholder background on the insights search page