### PR TITLE
feat: implement portfolio file upload functionality

### DIFF
--- a/src/app/(admin)/admin/portfolio/page.tsx
+++ b/src/app/(admin)/admin/portfolio/page.tsx
@@ -4,14 +4,20 @@ import { Input } from "@/components/ui/input";
 import * as XLSX from "xlsx";
 import PdfPreview from "@/components/admin/PdfPreview";
 import PortfolioComponentsPreview from "@/components/admin/PortfolioComponentsPreview";
+import { Button } from "@/components/ui/button";
+import PortfolioUploadConfirmDialog from "@/components/admin/PortfolioUploadConfirmDialog";
 
 export default function PortfolioPage() {
   const [file, setFile] = useState<File | null>(null);
   const [error, setError] = useState<string>("");
+  const [success, setSuccess] = useState<string>("");
+  const [uploading, setUploading] = useState(false);
   const [workbook, setWorkbook] = useState<XLSX.WorkBook | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setError("");
+    setSuccess("");
     const f = e.target.files?.[0];
     if (!f) return;
     if (!f.name.endsWith(".xlsm")) {
@@ -32,12 +38,50 @@ export default function PortfolioPage() {
     reader.readAsArrayBuffer(f);
   };
 
+  const handleUpload = async () => {
+    if (!file) return;
+    setError("");
+    setSuccess("");
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      const res = await fetch("/api/admin/portfolio", {
+        method: "POST",
+        body: formData,
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Upload failed.");
+      } else {
+        setSuccess("File uploaded successfully!");
+      }
+    } catch (e) {
+      setError("Upload failed.");
+    } finally {
+      setUploading(false);
+    }
+  };
+
   return (
     <div className="w-full mx-auto p-8">
       <h1 className="text-2xl font-bold mb-6">Portfolio Upload</h1>
       <div className="space-y-4">
         <Input type="file" accept=".xlsm" onChange={handleFileChange} />
+        <PortfolioUploadConfirmDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          onConfirm={handleUpload}
+          loading={uploading}
+          disabled={!file || uploading}
+          trigger={
+            <Button disabled={!file || uploading}>
+              {uploading ? "Uploading..." : "Upload"}
+            </Button>
+          }
+        />
         {error && <div className="text-red-500 text-sm">{error}</div>}
+        {success && <div className="text-green-600 text-sm">{success}</div>}
         {file && (
           <div className="text-sm text-gray-700">Uploaded: {file.name}</div>
         )}

--- a/src/app/api/admin/portfolio/route.ts
+++ b/src/app/api/admin/portfolio/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { uploadToBlob } from "@/lib/blob";
+
+export const runtime = "edge";
+
+export async function POST(req: NextRequest) {
+  const formData = await req.formData();
+  const file = formData.get("file");
+  if (!file || !(file instanceof File)) {
+    return NextResponse.json({ error: "No file uploaded." }, { status: 400 });
+  }
+  const result = await uploadToBlob(file, "portfolio");
+  if ("error" in result) {
+    return NextResponse.json({ error: result.error }, { status: 409 });
+  }
+  return NextResponse.json({ url: result.url });
+}

--- a/src/app/api/admin/posts/[id]/route.ts
+++ b/src/app/api/admin/posts/[id]/route.ts
@@ -4,7 +4,7 @@ import { db } from "@/db";
 import { posts, postTags } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import sanitizeHtml from "sanitize-html";
-import { deleteFromBlob, uploadToBlob } from "@/lib/blob";
+import { deleteFromBlob, uploadImageToBlob } from "@/lib/blob";
 
 const UpdatePostRequestSchema = z.object({
   title: z.string().min(1, "Title is required"),
@@ -38,7 +38,7 @@ export async function PUT(
     if (displayImage) {
       const environment = process.env.ENVIRONMENT;
       const environmentString = environment ? environment + "/" : "";
-      displayImageUrl = await uploadToBlob(
+      displayImageUrl = await uploadImageToBlob(
         displayImage,
         `posts/${slug}/${environmentString}display-image-${Date.now()}.jpg`,
       );

--- a/src/app/api/admin/posts/route.ts
+++ b/src/app/api/admin/posts/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import sanitizeHtml from "sanitize-html";
-import { uploadToBlob } from "@/lib/blob";
+import { uploadImageToBlob } from "@/lib/blob";
 import { db } from "@/db";
 import { posts, postTags } from "@/db/schema";
 import { desc } from "drizzle-orm";
@@ -28,7 +28,7 @@ export async function POST(request: Request) {
     if (displayImage) {
       const environment = process.env.ENVIRONMENT;
       const environmentString = environment ? environment + "/" : "";
-      displayImageUrl = await uploadToBlob(
+      displayImageUrl = await uploadImageToBlob(
         displayImage,
         `posts/${slug}/${environmentString}display-image-${Date.now()}.jpg`,
       );

--- a/src/components/admin/PortfolioUploadConfirmDialog.tsx
+++ b/src/components/admin/PortfolioUploadConfirmDialog.tsx
@@ -1,0 +1,54 @@
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import React from "react";
+
+interface PortfolioUploadConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  loading?: boolean;
+  disabled?: boolean;
+  trigger: React.ReactNode;
+}
+
+export default function PortfolioUploadConfirmDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  loading = false,
+  disabled = false,
+  trigger,
+}: PortfolioUploadConfirmDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Confirm Upload</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to upload this file to the portfolio? This
+            action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={loading}>Cancel</AlertDialogCancel>
+          <AlertDialogAction asChild>
+            <Button onClick={onConfirm} disabled={loading || disabled}>
+              {loading ? "Uploading..." : "Confirm"}
+            </Button>
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/lib/blob.ts
+++ b/src/lib/blob.ts
@@ -1,6 +1,6 @@
-import { del, put } from "@vercel/blob";
+import { del, put, head } from "@vercel/blob";
 
-export async function uploadToBlob(
+export async function uploadImageToBlob(
   base64Image: string,
   filename: string,
 ): Promise<string> {
@@ -19,6 +19,28 @@ export async function uploadToBlob(
   });
 
   return url;
+}
+
+// Generic file upload for any file type, with folder support and existence check
+export async function uploadToBlob(
+  file: File,
+  folder: string = "",
+): Promise<{ url: string } | { error: string }> {
+  const filename = folder ? `${folder}/${file.name}` : file.name;
+  // Check if file exists
+  try {
+    await head(filename); // Throws if not found
+    return { error: "File with the same name already exists." };
+  } catch (e) {
+    // Not found, continue
+    console.log("File not found, continuing", e);
+  }
+  // Upload
+  const { url } = await put(filename, file, {
+    access: "public",
+    addRandomSuffix: false,
+  });
+  return { url };
 }
 
 export async function downloadFromBlob(url: string): Promise<string> {


### PR DESCRIPTION
This pull request introduces functionality for uploading files to a portfolio, refactors existing blob upload methods, and adds confirmation dialogs for file uploads. The changes include implementing a new API endpoint for portfolio uploads, enhancing user interface components, and updating blob upload logic to support different file types and scenarios.

### Portfolio Upload Feature:

* **New API Endpoint for Portfolio Uploads**: Added `POST` handler in `src/app/api/admin/portfolio/route.ts` to handle file uploads to blob storage. Includes error handling for missing files and duplicate file names. [[1]](diffhunk://#diff-bef23369afde9eefea05515dcda4d9894b9935ffc3ce40748096ccebcdcee909R1-R17) [[2]](diffhunk://#diff-07ca2f75cde123b30cbcfebce12561191c7567ed28c04d14989bfbee89309910R24-R45)
* **Confirmation Dialog for File Uploads**: Introduced `PortfolioUploadConfirmDialog` component in `src/components/admin/PortfolioUploadConfirmDialog.tsx` to confirm uploads with a user-friendly interface.
* **UI Enhancements in `PortfolioPage`**: Updated `src/app/(admin)/admin/portfolio/page.tsx` to include a file upload button, success/error messages, and integration with the confirmation dialog. [[1]](diffhunk://#diff-201a859a05002c66d890f02bd106e7d2f02998516bec6b9615d886740b6ce72fR7-R20) [[2]](diffhunk://#diff-201a859a05002c66d890f02bd106e7d2f02998516bec6b9615d886740b6ce72fR41-R84)

### Blob Upload Refactor:

* **Refactored Blob Upload Methods**: Replaced `uploadToBlob` with `uploadImageToBlob` for image uploads and introduced a generic `uploadToBlob` method for handling various file types. Updated relevant API routes to use the new methods. [[1]](diffhunk://#diff-07ca2f75cde123b30cbcfebce12561191c7567ed28c04d14989bfbee89309910L1-R3) [src/app/api/admin/posts/[id]/route.tsL7-R7](diffhunk://#diff-d6a09a1231ff07ddd9b21724a6c5652b0752f62d5cbb236604cf903066fda147L7-R7), [src/app/api/admin/posts/[id]/route.tsL41-R41](diffhunk://#diff-d6a09a1231ff07ddd9b21724a6c5652b0752f62d5cbb236604cf903066fda147L41-R41), [[2]](diffhunk://#diff-38f52e85ce2a423546ed2a59c8888e0d1d2115179159f3e35a95c3a3d871cc0eL4-R4) [[3]](diffhunk://#diff-38f52e85ce2a423546ed2a59c8888e0d1d2115179159f3e35a95c3a3d871cc0eL31-R31)