### PR TITLE
formatted percentage values

### DIFF
--- a/src/app/(admin)/admin/excel/formatters.ts
+++ b/src/app/(admin)/admin/excel/formatters.ts
@@ -1,0 +1,32 @@
+const decimalToPercentage = (value: number) => Number((value * 100).toFixed(2));
+
+// Converts a cell-like value to a percentage number if numeric; otherwise returns defaultValue.
+export const toPercentNumber = (
+  value: unknown,
+  defaultValue: number = 0,
+): number => {
+  const numericValue =
+    typeof value === "number"
+      ? value
+      : value === undefined || value === null
+        ? NaN
+        : Number(value);
+
+  return Number.isFinite(numericValue)
+    ? decimalToPercentage(numericValue)
+    : defaultValue;
+};
+
+// Converts a value to its percentage string if numeric; preserves original string otherwise.
+export const toPercentStringIfNumeric = (value: unknown): string => {
+  const stringValue =
+    value === undefined || value === null ? "" : String(value).trim();
+
+  if (stringValue === "") return "";
+
+  const numericValue = Number(stringValue);
+
+  return Number.isFinite(numericValue)
+    ? decimalToPercentage(numericValue).toString()
+    : stringValue;
+};


### PR DESCRIPTION
This pull request refactors and improves the handling of percentage values extracted from Excel. The main changes include introducing new formatter functions for consistent percentage conversion and updating utility functions to use these formatters.

* Added `toPercentNumber` and `toPercentStringIfNumeric` functions to `formatters.ts` for consistent conversion of numeric and string values to percentage format.
* Refactored `getInceptionPerformanceData` to use `toPercentNumber` for converting Excel cell values to percentages, improving clarity and reducing duplicate logic.
* Updated `extractTwoColumnThreeRows` to use `toPercentStringIfNumeric`, ensuring extracted values are formatted as percentages when appropriate and preserving original strings otherwise.