### PR TITLE
adjust strategy performance to use 12m rolling vol column as source

### DIFF
--- a/src/app/(admin)/admin/excel/utils.ts
+++ b/src/app/(admin)/admin/excel/utils.ts
@@ -96,7 +96,7 @@ export const getInceptionPerformanceData = (
   // x axis
   const dateCol = options?.dateCol ?? "D";
 
-  // y axes
+  // y axes - these will vary per product
   const series1Col = options?.series1Col ?? "H";
   const series2Col = options?.series2Col ?? "I";
 

--- a/src/app/(admin)/admin/portfolio/page.tsx
+++ b/src/app/(admin)/admin/portfolio/page.tsx
@@ -8,6 +8,8 @@ import { Button } from "@/components/ui/button";
 import PortfolioUploadConfirmDialog from "@/components/admin/PortfolioUploadConfirmDialog";
 import LiveSourceConfirmDialog from "@/components/admin/LiveSourceConfirmDialog";
 
+const acceptedFileTypes = [".xlsm", ".xlsx"];
+
 export default function PortfolioPage() {
   const [file, setFile] = useState<File | null>(null);
   const [error, setError] = useState<string>("");
@@ -23,8 +25,11 @@ export default function PortfolioPage() {
     setSuccess("");
     const f = e.target.files?.[0];
     if (!f) return;
-    if (!f.name.endsWith(".xlsm")) {
-      setError("Only .xlsm files are allowed.");
+    const isValidFileType = acceptedFileTypes.some((ext) =>
+      f.name.endsWith(ext),
+    );
+    if (!isValidFileType) {
+      setError(`Only ${acceptedFileTypes.join(" and ")} files are allowed.`);
       setFile(null);
       setWorkbook(null);
       return;
@@ -96,7 +101,11 @@ export default function PortfolioPage() {
     <div className="w-full mx-auto p-8">
       <h1 className="text-2xl font-bold mb-6">Portfolio Upload</h1>
       <div className="space-y-4">
-        <Input type="file" accept=".xlsm" onChange={handleFileChange} />
+        <Input
+          type="file"
+          accept={acceptedFileTypes.join(",")}
+          onChange={handleFileChange}
+        />
         <PortfolioUploadConfirmDialog
           open={dialogOpen}
           onOpenChange={setDialogOpen}

--- a/src/components/admin/PDF.tsx
+++ b/src/components/admin/PDF.tsx
@@ -11,7 +11,7 @@ export default function PDF({ workbook }: { workbook: XLSX.WorkBook }) {
     cumulativePerformance,
     twelveMonthCumulativePerformance,
     cumulativeStrategyPerformance,
-  } = getAllChartData(workbook, { inceptionPerformance: { series2Col: "K" } });
+  } = getAllChartData(workbook);
 
   return (
     <div className="grid grid-cols-2 gap-6">


### PR DESCRIPTION
Adjusted the strategy performance graph to use just the 12m rolling vol column as the source (Column I). This column will vary per product but will be the same for both the pdf and webpage for a specific product. I'm setting it to one fixed column source for now for the sake of MVP.

Also added `.xlsx` to the list of allowed file types