### PR TITLE
PDF key buys/sells tables

### DIFF
--- a/src/app/(admin)/admin/excel/utils.ts
+++ b/src/app/(admin)/admin/excel/utils.ts
@@ -13,28 +13,25 @@ export const getAllChartData = (
     workbook,
     "6.TopThreeContr",
   );
-
   const bottomThreeContributorsSheet = getWorksheetByName(
     workbook,
     "7.BottomThreeContr",
   );
-
   const cumulativePerformanceSheet = getWorksheetByName(
     workbook,
     "8.CumulativePerfDiscrete",
   );
-
   const twelveMonthCumulativePerformanceSheet = getWorksheetByName(
     workbook,
     "9.12mPerfDiscrete",
   );
-
   const inceptionPerfSheet = getWorksheetByName(
     workbook,
     "12.InceptionPerfData",
   );
-
   const fundInfoSheet = getWorksheetByName(workbook, "14.FundInfo");
+  const keyBuysSheet = getWorksheetByName(workbook, "10.KeyBuys");
+  const keySellsSheet = getWorksheetByName(workbook, "11.KeySells");
 
   return {
     topThreeContributors: extractTwoColumnData(
@@ -65,6 +62,8 @@ export const getAllChartData = (
       options?.inceptionPerformance,
     ),
     fundInfo: extractTwoColumnData(fundInfoSheet),
+    keyBuys: extractRowsData(keyBuysSheet, ["A", "B", "C", "D"], 1),
+    keySells: extractRowsData(keySellsSheet, ["A", "B", "C", "D"], 1),
   };
 };
 
@@ -156,7 +155,7 @@ export const getInceptionPerformanceData = (
   };
 };
 
-export type TwoColumnData = [string, string][];
+export type KeyValuePairData = [string, string][];
 
 /**
  * Extracts a two-column, three-row data structure from a given worksheet.
@@ -165,7 +164,7 @@ export type TwoColumnData = [string, string][];
  * @param {number} [startRow=1] - The starting row number (1-based).
  * @param {string} [startCol="A"] - The starting column letter.
  * @param {number} [numRows] - Optional. The number of rows to extract including header row. If not provided, extraction continues until two consecutive empty rows are found.
- * @returns {TwoColumnData} An array of [string, string] pairs representing the extracted rows.
+ * @returns {KeyValuePairData} An array of [string, string] pairs representing the extracted rows.
  */
 
 export function extractTwoColumnData(
@@ -173,8 +172,8 @@ export function extractTwoColumnData(
   startRow: number = 1,
   startCol: string = "A",
   numRows?: number,
-): TwoColumnData {
-  const rows: TwoColumnData = [];
+): KeyValuePairData {
+  const rows: KeyValuePairData = [];
   const colB = String.fromCharCode(startCol.charCodeAt(0) + 1); // Next column
 
   // Helper function to extract cell values for a given row
@@ -222,4 +221,40 @@ export function extractTwoColumnData(
     }
   }
   return rows;
+}
+
+/**
+ * Extracts 2 rows from an Excel worksheet, where the first row contains keys
+ * and the second row contains corresponding values, from the specified columns.
+ *
+ * @param {XLSX.WorkSheet} sheet - The worksheet to extract data from
+ * @param {string[]} columns - Array of column letters (e.g., ['A', 'B', 'C'])
+ * @param {number} startRow - Starting row number (1-based) for the keys
+ * @returns {KeyValuePairData} Array of key-value pairs, where each pair is a [string, string]
+ */
+export function extractRowsData(
+  sheet: XLSX.WorkSheet,
+  columns: string[],
+  startRow: number,
+): KeyValuePairData {
+  const keyRow = startRow;
+  const valueRow = startRow + 1;
+  const pairs: KeyValuePairData = [];
+
+  for (const col of columns) {
+    // Get the key from the first row of the specified column
+    const keyCellRef = `${col}${keyRow}`;
+    const keyCell = sheet[keyCellRef];
+    const key = keyCell ? toPercentStringIfNumeric(keyCell.v) : "";
+
+    // Get the value from the second row of the specified column
+    const valueCellRef = `${col}${valueRow}`;
+    const valueCell = sheet[valueCellRef];
+    const value = valueCell ? toPercentStringIfNumeric(valueCell.v) : "";
+
+    // Push the key-value pair to the result array
+    pairs.push([key, value]);
+  }
+
+  return pairs;
 }

--- a/src/components/admin/HorizontalTable.tsx
+++ b/src/components/admin/HorizontalTable.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TwoColumnData } from "@/app/(admin)/admin/excel/utils";
+import { KeyValuePairData } from "@/app/(admin)/admin/excel/utils";
 import {
   Table,
   TableBody,
@@ -18,22 +18,36 @@ const fontSize: Record<FontSize2, string> = {
 };
 
 interface HorizontalTableProps {
-  data: TwoColumnData;
+  data: KeyValuePairData;
   textSize?: FontSize2;
+  secondHeaderText?: string;
+  emptyStateText?: string;
+  classNames?: string;
 }
 
 export default function HorizontalTable({
   data,
   textSize,
+  secondHeaderText,
+  emptyStateText,
+  classNames = "",
 }: HorizontalTableProps) {
   // Transpose the data so columns become rows
   const transposedData =
     data[0]?.map((_, colIndex) => data.map((row) => row[colIndex])) || [];
 
+  const isEmptyValues = data.every((pair) => pair[1] === "");
+  const showEmptyState = isEmptyValues && emptyStateText;
+
   return (
     <Table
-      className={`${articulat.className} ${textSize && fontSize[textSize]}`}
+      className={`${articulat.className} ${textSize && fontSize[textSize]} ${classNames}`}
     >
+      {secondHeaderText && (
+        <TableHeader className="border-b">
+          <TableHead>{secondHeaderText}</TableHead>
+        </TableHeader>
+      )}
       <TableHeader>
         <TableRow>
           {data.map((row, idx) => (
@@ -41,15 +55,22 @@ export default function HorizontalTable({
           ))}
         </TableRow>
       </TableHeader>
-      <TableBody>
-        {transposedData.slice(1, 2).map((column, colIdx) => (
-          <TableRow key={colIdx}>
-            {column.map((value, rowIdx) => (
-              <TableCell key={rowIdx}>{value}</TableCell>
-            ))}
-          </TableRow>
-        ))}
-      </TableBody>
+
+      {showEmptyState ? (
+        <TableHeader className="border-b">
+          <TableHead>{emptyStateText}</TableHead>
+        </TableHeader>
+      ) : (
+        <TableBody>
+          {transposedData.slice(1, 2).map((column, colIdx) => (
+            <TableRow key={colIdx}>
+              {column.map((value, rowIdx) => (
+                <TableCell key={rowIdx}>{value}</TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      )}
     </Table>
   );
 }

--- a/src/components/admin/PDF.tsx
+++ b/src/components/admin/PDF.tsx
@@ -24,6 +24,8 @@ export default function PDF({
     twelveMonthCumulativePerformance,
     cumulativeStrategyPerformance,
     fundInfo,
+    keyBuys,
+    keySells,
   } = getAllChartData(workbook);
 
   const headerDate = getDateFromFileName(fileName, "MMMM YYY");
@@ -73,7 +75,23 @@ export default function PDF({
       <Page headerDate={headerDate} footerDate={footerDate}>
         <div className="p-4">
           <HorizontalTable data={fundInfo} textSize="xs" />
+
           <SectionTitle>Portfolio Highlights</SectionTitle>
+
+          <HorizontalTable
+            data={keyBuys}
+            textSize="xs"
+            secondHeaderText="Key Buys"
+            emptyStateText="There were no key buys this month"
+          />
+
+          <HorizontalTable
+            classNames="mt-4"
+            data={keySells}
+            textSize="xs"
+            secondHeaderText="Key Sells"
+            emptyStateText="There were no key sells this month"
+          />
         </div>
       </Page>
 

--- a/src/components/admin/TwoColumnTable.tsx
+++ b/src/components/admin/TwoColumnTable.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TwoColumnData } from "@/app/(admin)/admin/excel/utils";
+import { KeyValuePairData } from "@/app/(admin)/admin/excel/utils";
 import {
   Table,
   TableBody,
@@ -18,7 +18,7 @@ const fontSize: Record<FontSize2, string> = {
 };
 
 interface TwoColumnTableProps {
-  data: TwoColumnData;
+  data: KeyValuePairData;
   textSize?: FontSize2;
 }
 


### PR DESCRIPTION
- Added key buys and sells tables.
- Updated horizontal table to allow second headers and empty state

<img width="410" height="170" alt="image" src="https://github.com/user-attachments/assets/4127e06a-ffd6-4d4f-96a9-9b68fd8cc47f" />
