### PR TITLE
Added new monthly performance table + formatting updates

### DIFF
--- a/src/app/(admin)/admin/excel/formatters.ts
+++ b/src/app/(admin)/admin/excel/formatters.ts
@@ -1,4 +1,4 @@
-const decimalToPercentage = (value: number) => Number((value * 100).toFixed(2));
+const decimalToPercentage = (value: number) => (value * 100).toFixed(2);
 
 // Converts a cell-like value to a percentage number if numeric; otherwise returns defaultValue.
 export const toPercentNumber = (
@@ -13,7 +13,7 @@ export const toPercentNumber = (
         : Number(value);
 
   return Number.isFinite(numericValue)
-    ? decimalToPercentage(numericValue)
+    ? Number(decimalToPercentage(numericValue))
     : defaultValue;
 };
 
@@ -27,6 +27,6 @@ export const toPercentStringIfNumeric = (value: unknown): string => {
   const numericValue = Number(stringValue);
 
   return Number.isFinite(numericValue)
-    ? decimalToPercentage(numericValue).toString()
+    ? `${decimalToPercentage(numericValue).toString()}%`
     : stringValue;
 };

--- a/src/app/(admin)/admin/excel/utils.ts
+++ b/src/app/(admin)/admin/excel/utils.ts
@@ -269,10 +269,10 @@ export function extractRowsData(
  * Reads 14 columns across and continues down until an empty row is found.
  *
  * @param {XLSX.WorkSheet} sheet - The worksheet to extract data from
- * @param {string} [headerCol="I"] - The starting column letter for headers
+ * @param {string} [headerCol="J"] - The starting column letter for headers
  * @param {number} [headerRow=3] - The row number containing headers
  * @param {number} [numColumns=14] - Number of columns to read
- * @returns {{headerCellValue: string, headers: string[], data: string[][]}} Object containing header cell value, headers array and data rows array
+ * @returns {{headerCellValue: string, data: string[][]}} Object containing header cell value and data rows array
  */
 export function extractTableData(
   sheet: XLSX.WorkSheet,

--- a/src/app/(public)/fund-info/page.tsx
+++ b/src/app/(public)/fund-info/page.tsx
@@ -47,9 +47,6 @@ async function FundInfoContent() {
           {new Date(auditResult.data.uploadDate ?? "").toLocaleDateString()}
         </div>
         <div className="mt-6">
-          <h2 className="text-lg text-pure-white font-semibold mb-2">
-            Portfolio Components
-          </h2>
           <FundData workbook={workbook} />
         </div>
       </div>

--- a/src/components/admin/FundData.tsx
+++ b/src/components/admin/FundData.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import * as XLSX from "xlsx";
 import TwoColumnTable from "@/components/admin/TwoColumnTable";
 import { getAllChartData } from "@/app/(admin)/admin/excel/utils";
-import HorizontalTable from "./HorizontalTable";
+import HorizontalTable, { HorizontalTableRows } from "./HorizontalTable";
 import { InceptionPerformanceChart } from "./InceptionPerformanceChart";
 
 interface PortfolioComponentsPreview {
@@ -16,30 +16,41 @@ const FundData = ({ workbook }: PortfolioComponentsPreview) => {
     cumulativePerformance,
     twelveMonthCumulativePerformance,
     cumulativeStrategyPerformance,
+    monthlyPerformance,
   } = getAllChartData(workbook);
   return (
     <div>
-      <div className="mt-4">
-        {topThreeContributors && <TwoColumnTable data={topThreeContributors} />}
-      </div>
-      <div className="mt-4">
-        {bottomThreeContributors && (
-          <TwoColumnTable data={bottomThreeContributors} />
-        )}
-      </div>
-      <div className="mt-4">
-        {cumulativePerformance && (
-          <HorizontalTable data={cumulativePerformance} />
-        )}
-      </div>
-      <div className="mt-4">
-        {twelveMonthCumulativePerformance && (
-          <HorizontalTable data={twelveMonthCumulativePerformance} />
-        )}
-      </div>
-      <div className="mt-4">
-        <InceptionPerformanceChart data={cumulativeStrategyPerformance} />
-      </div>
+      <section>
+        <div className="mt-4">
+          {topThreeContributors && (
+            <TwoColumnTable data={topThreeContributors} />
+          )}
+        </div>
+        <div className="mt-4">
+          {bottomThreeContributors && (
+            <TwoColumnTable data={bottomThreeContributors} />
+          )}
+        </div>
+        <div className="mt-4">
+          {cumulativePerformance && (
+            <HorizontalTable data={cumulativePerformance} />
+          )}
+        </div>
+        <div className="mt-4">
+          {twelveMonthCumulativePerformance && (
+            <HorizontalTable data={twelveMonthCumulativePerformance} />
+          )}
+        </div>
+        <div className="mt-4">
+          <InceptionPerformanceChart data={cumulativeStrategyPerformance} />
+        </div>
+        <div className="mt-4">
+          <HorizontalTableRows
+            data={monthlyPerformance.data}
+            headerText={monthlyPerformance.headerCellValue}
+          />
+        </div>
+      </section>
     </div>
   );
 };

--- a/src/components/admin/HorizontalTable.tsx
+++ b/src/components/admin/HorizontalTable.tsx
@@ -25,6 +25,14 @@ interface HorizontalTableProps {
   classNames?: string;
 }
 
+interface HorizontalTableRowsProps {
+  data: string[][];
+  textSize?: FontSize2;
+  headerText?: string;
+  emptyStateText?: string;
+  classNames?: string;
+}
+
 export default function HorizontalTable({
   data,
   textSize,
@@ -72,5 +80,46 @@ export default function HorizontalTable({
         </TableBody>
       )}
     </Table>
+  );
+}
+
+export function HorizontalTableRows({
+  data,
+  textSize,
+  headerText,
+  emptyStateText,
+  classNames = "",
+}: HorizontalTableRowsProps) {
+  const isEmpty =
+    data.length === 0 || data.every((row) => row.every((cell) => cell === ""));
+  const showEmptyState = isEmpty && emptyStateText;
+
+  return (
+    <>
+      {headerText && (
+        <TableHeader className="border-b">
+          <TableHead>{headerText}</TableHead>
+        </TableHeader>
+      )}
+      <Table
+        className={`${articulat.className} ${textSize && fontSize[textSize]} ${classNames}`}
+      >
+        {showEmptyState ? (
+          <TableHeader className="border-b">
+            <TableHead>{emptyStateText}</TableHead>
+          </TableHeader>
+        ) : (
+          <TableBody>
+            {data.map((row, rowIdx) => (
+              <TableRow key={rowIdx}>
+                {row.map((cell, cellIdx) => (
+                  <TableCell key={cellIdx}>{cell}</TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        )}
+      </Table>
+    </>
   );
 }

--- a/src/components/admin/PDF.tsx
+++ b/src/components/admin/PDF.tsx
@@ -28,8 +28,8 @@ export default function PDF({
     keySells,
   } = getAllChartData(workbook);
 
-  const headerDate = getDateFromFileName(fileName, "MMMM YYY");
-  const footerDate = getDateFromFileName(fileName, "dd/MM/YYY");
+  const headerDate = getDateFromFileName(fileName, "MMMM yyy");
+  const footerDate = getDateFromFileName(fileName, "dd/MM/yyy");
 
   if (!headerDate) return <div>error: could not get header date</div>;
   if (!footerDate) return <div>error: could not get footer date</div>;


### PR DESCRIPTION
This pull request adds support for extracting and displaying monthly performance data from Excel workbooks in the admin interface. It introduces a new utility function for extracting table data, updates formatting for percentage values, and enhances the UI to present the new data using a reusable table component.

**Excel Data Extraction and Formatting:**

- Added `extractTableData` utility function to read table data (including headers and rows) from a specified worksheet, starting at a configurable cell and column count. This function is used to extract monthly performance data from the "13.MonthlyPerf" sheet.
- Updated percentage formatting logic in `formatters.ts` to ensure consistent string and numeric conversions, and to append a '%' symbol when displaying percentages as strings. [[1]](diffhunk://#diff-bb8e4d6357479acd96ba9619c1c24abcb8165844ff1f058082a5267852f032a8L1-R1) [[2]](diffhunk://#diff-bb8e4d6357479acd96ba9619c1c24abcb8165844ff1f058082a5267852f032a8L16-R16) [[3]](diffhunk://#diff-bb8e4d6357479acd96ba9619c1c24abcb8165844ff1f058082a5267852f032a8L30-R30)

**UI Enhancements:**

- Modified `FundData` component to display the extracted monthly performance data using the new `HorizontalTableRows` component, including the table header and formatted percentage values. [[1]](diffhunk://#diff-f32a943d79feffdee35a44a818bf709aeb11fc19ffc5128053a9f9f5462b5a2dR19-R27) [[2]](diffhunk://#diff-f32a943d79feffdee35a44a818bf709aeb11fc19ffc5128053a9f9f5462b5a2dR47-R53)
- Added `HorizontalTableRows` component to render row-based tables with optional headers and empty states, making it reusable for future tabular data needs. [[1]](diffhunk://#diff-8c746e87a82def9a476bdca6edbbf867a5f886888a8993b4390aa2887dec088dR28-R35) [[2]](diffhunk://#diff-8c746e87a82def9a476bdca6edbbf867a5f886888a8993b4390aa2887dec088dR85-R125)

**Miscellaneous:**

- Fixed date formatting patterns in the `PDF` component to use the correct year format (`yyy` instead of `YYY`).
- Removed the "Portfolio Components" header from the public fund info page for a cleaner UI.