### PR TITLE
Refactor insights search results

### DIFF
--- a/src/app/(public)/insights/InsightsListView.tsx
+++ b/src/app/(public)/insights/InsightsListView.tsx
@@ -1,10 +1,9 @@
 "use client";
 import MultiSelect, { Option } from "@/components/admin/MultiSelect";
 import { Button } from "@/components/ui/button";
-import { Separator } from "@/components/ui/separator";
 import { Pagination } from "@/components/public/Pagination";
+import { InsightSearchItem } from "@/components/public/InsightSearchItem";
 import { SearchParams } from "@/lib/SearchParams";
-import Link from "next/link";
 import { useState } from "react";
 import {
   ReadonlyURLSearchParams,
@@ -75,7 +74,7 @@ export const InsightsListView = ({
 
   return (
     <>
-      <div className="flex mb-8">
+      <div className="flex mb-8 max-w-[1100px] mx-auto">
         <MultiSelect
           selected={selectedTags}
           onChange={setSelectedTags}
@@ -101,24 +100,12 @@ export const InsightsListView = ({
         </div>
       </div>
 
-      <ul className="mb-8">
-        {posts.map(({ id, title, slug, createdAt }) => (
-          <li key={id}>
-            <Link
-              href={`/insights/${slug}`}
-              className="text-orange-500 hover:text-orange-700"
-            >
-              {title}
-            </Link>
-            {createdAt && (
-              <h3 className="text-pure-white">
-                This insight was created on {createdAt.toDateString()}
-              </h3>
-            )}
-
-            <Separator />
-          </li>
-        ))}
+      <ul className="mb-8 px-8">
+        <div className="grid grid-cols-2 gap-8">
+          {posts.map((post) => (
+            <InsightSearchItem key={post.id} post={post} />
+          ))}
+        </div>
       </ul>
       <Pagination hasNext={hasNext} hasPrevious={hasPrevious} />
     </>

--- a/src/components/public/InsightSearchItem.tsx
+++ b/src/components/public/InsightSearchItem.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import { format } from "date-fns";
+import { Card } from "../ui/card";
+import { Post } from "@/db/schema";
+import { articulat } from "@/fonts";
+import Image from "next/image";
+
+interface InsightSearchItemProps {
+  post: Post;
+}
+
+export const InsightSearchItem = ({ post }: InsightSearchItemProps) => {
+  return (
+    <li key={post.id}>
+      <Card className="bg-pure-white/10 backdrop-blur-[10px] p-4 h-full md:min-h-[300px] rounded-2xl">
+        <div className="flex gap-6">
+          <Image
+            className="rounded-xl min-h-[256px] min-w-[313px] max-h-[300px]"
+            src={post.displayImageUrl || "../landscape-placeholder.svg"}
+            alt="file icon"
+            width={313}
+            height={256}
+          />
+          <div>
+            <Link
+              href={`/insights/${post.slug}`}
+              className="text-pure-white text-xl font-semibold "
+            >
+              {post.title}
+            </Link>
+            {post.createdAt && (
+              <h3 className="text-pure-white mb-3">
+                {format(post.createdAt, "dd/MM/yyyy")}
+              </h3>
+            )}
+            <p
+              className={`text-pure-white mb-4 ${articulat.className} max-h-[120px] max-w-1/3 overflow-hidden text-ellipsis`}
+            >
+              {post.excerpt}
+            </p>
+          </div>
+        </div>
+      </Card>
+    </li>
+  );
+};

--- a/src/data-access-layer/posts.ts
+++ b/src/data-access-layer/posts.ts
@@ -11,7 +11,7 @@ interface SearchParams {
   tags?: string;
 }
 
-const PAGE_LIMIT = 3;
+const PAGE_LIMIT = 4;
 
 const SearchParamsSchema = z.object({
   page: z.coerce.number().min(1, "Page must be non zero").optional(),


### PR DESCRIPTION
This pull request updates the public insights list view to improve its visual layout and user experience. The main change is the introduction of a new `InsightSearchItem` component, which displays each insight in a card format with images and metadata, replacing the previous simple list of links. The grid layout and card design make the insights more visually appealing and easier to browse. Additionally, the number of insights shown per page has been increased.

**UI/UX Improvements:**

* Replaced the old list view of insights with a new grid layout using the `InsightSearchItem` component, which displays each post as a card with an image, title, date, and excerpt. 
* Centered and constrained the filter bar's width.

**Pagination and Data Handling:**

* Increased the number of insights displayed per page from 3 to 4 to show more content per page.

<img width="1914" height="888" alt="image" src="https://github.com/user-attachments/assets/4e7878ce-a6f7-4dde-b6b7-7be27cd9abc9" />
