### PR TITLE
Fixed insights search item width

### DIFF
--- a/src/app/(public)/insights/page.tsx
+++ b/src/app/(public)/insights/page.tsx
@@ -11,7 +11,7 @@ const Insights = async ({
   const { data: posts, hasNextPage, hasPrevPage } = await getPosts(query);
   const { data: tags } = await getTags();
   return (
-    <div>
+    <div className="w-full">
       <InsightsListView
         posts={posts}
         tags={tags}

--- a/src/components/public/InsightSearchItem.tsx
+++ b/src/components/public/InsightSearchItem.tsx
@@ -13,20 +13,23 @@ export const InsightSearchItem = ({ post }: InsightSearchItemProps) => {
   return (
     <li key={post.id}>
       <Card className="bg-pure-white/10 backdrop-blur-[10px] p-4 h-full md:min-h-[300px] rounded-2xl">
-        <div className="flex gap-6">
-          <Image
-            className="rounded-xl min-h-[256px] min-w-[313px] max-h-[300px]"
-            src={post.displayImageUrl || "../landscape-placeholder.svg"}
-            alt="file icon"
-            width={313}
-            height={256}
-          />
-          <div>
+        <article className="flex flex-col md:flex-row gap-4 md:gap-6">
+          <div className="flex-shrink-0">
+            <Image
+              className="rounded-xl w-full md:w-[313px] h-[200px] md:h-[256px] object-cover"
+              src={post.displayImageUrl || "../landscape-placeholder.svg"}
+              alt={`Cover image for ${post.title}`}
+              width={313}
+              height={256}
+            />
+          </div>
+          <div className="flex-1 min-w-0">
+            {/* min-w-0 prevents flex item overflow */}
             <Link
               href={`/insights/${post.slug}`}
               className="text-pure-white text-xl font-semibold "
             >
-              {post.title}
+              <h2>{post.title}</h2>
             </Link>
             {post.createdAt && (
               <h3 className="text-pure-white mb-3">
@@ -34,12 +37,12 @@ export const InsightSearchItem = ({ post }: InsightSearchItemProps) => {
               </h3>
             )}
             <p
-              className={`text-pure-white mb-4 ${articulat.className} max-h-[120px] max-w-1/3 overflow-hidden text-ellipsis`}
+              className={`text-pure-white mb-4 ${articulat.className} max-h-[120px] max-w-2/3 overflow-hidden text-ellipsis`}
             >
               {post.excerpt}
             </p>
           </div>
-        </div>
+        </article>
       </Card>
     </li>
   );


### PR DESCRIPTION
This pull request improves the layout and accessibility of the insights page and individual insight cards. The main changes include updating the structure and styling of the `InsightSearchItem` component for better responsiveness and accessibility, and refining the container styling in the insights page.

Layout and accessibility improvements:

* [`src/components/public/InsightSearchItem.tsx`](diffhunk://#diff-28c084f190a2dccdea0a451a320fa7fac48775b34302b69b19709aeb6deb143fL16-R45): Refactored the card layout to use a responsive `article` element with flexbox, improved image sizing and aspect ratio handling, updated the image `alt` attribute for accessibility, and changed the title to an `h2` element within the link for better semantic structure. Also adjusted excerpt width and overflow handling for improved readability.

Styling enhancements:

* [`src/app/(public)/insights/page.tsx`](diffhunk://#diff-f42b6ca29d53d1c512a26c543f32136fdadfb0cb66ddf75216e3ba4a05007ab6L14-R14): Updated the main container to use a `w-full` class for consistent full-width layout.